### PR TITLE
Forward arguments from claude-vm to the underlying claude command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ claude-vm
 
 Clones the template into a fresh VM, mounts your current directory, and runs `claude --dangerously-skip-permissions`. The VM is deleted when Claude exits.
 
+Any arguments passed to `claude-vm` are forwarded to the `claude` command:
+
+```bash
+claude-vm -p "fix all lint errors"        # Run with a prompt
+claude-vm --resume                         # Resume previous session
+claude-vm -c "explain this codebase"       # Continue conversation
+```
+
 ### Debug shell
 
 ```bash
@@ -77,7 +85,7 @@ docker compose up -d
 ## How it works
 
 1. **`claude-vm-setup`** creates a Debian 13 VM with Lima, installs dev tools + Chrome + Claude Code, and stops it as a reusable template
-2. **`claude-vm`** clones the template, mounts your working directory read-write, runs optional `.claude-vm.runtime.sh`, then launches Claude with full permissions
+2. **`claude-vm [args]`** clones the template, mounts your working directory read-write, runs optional `.claude-vm.runtime.sh`, then launches Claude with full permissions (forwarding any arguments to the `claude` command)
 3. On exit, the cloned VM is stopped and deleted. The template persists for reuse
 
 Ports opened inside the VM (e.g. by Docker containers) are automatically forwarded to your host by Lima.

--- a/claude-vm.sh
+++ b/claude-vm.sh
@@ -8,7 +8,7 @@
 #
 # Functions:
 #   claude-vm-setup  - Create the VM template (run once)
-#   claude-vm        - Run Claude in a fresh VM with cwd mounted
+#   claude-vm [args] - Run Claude in a fresh VM with cwd mounted (args forwarded to claude)
 #   claude-vm-shell  - Open a debug shell in a fresh VM
 
 CLAUDE_VM_TEMPLATE="claude-template"
@@ -111,6 +111,7 @@ VMEOF
 }
 
 claude-vm() {
+  local args=("$@")
   local vm_name="claude-$(basename "$(pwd)" | tr -cs 'a-zA-Z0-9' '-' | sed 's/^-//;s/-$//')-$$"
   local host_dir="$(pwd)"
 
@@ -139,7 +140,7 @@ claude-vm() {
     limactl shell --workdir "$host_dir" "$vm_name" bash -l < "${host_dir}/.claude-vm.runtime.sh"
   fi
 
-  limactl shell --workdir "$host_dir" "$vm_name" claude --dangerously-skip-permissions
+  limactl shell --workdir "$host_dir" "$vm_name" claude --dangerously-skip-permissions "${args[@]}"
 
   _claude_vm_cleanup
   trap - EXIT INT TERM


### PR DESCRIPTION
Allows passing CLI options like -p, --resume, or -c directly to claude-vm, which are forwarded to the claude command inside the VM.