### PR TITLE
Fix OpenCode install script and remove yolo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run AI coding agents inside sandboxed Linux VMs. The agent gets full autonomy wh
 
 Uses [Lima](https://lima-vm.io/) to create lightweight Debian VMs on macOS and Linux. Ships with dev tools, Docker, and a headless Chrome browser with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) pre-configured.
 
-Supports [Claude Code](https://claude.ai/code), [OpenCode](https://github.com/opencode-ai/opencode), and [Codex CLI](https://github.com/openai/codex) out of the box. Other agents can be run via `agent-vm shell`.
+Supports [Claude Code](https://claude.ai/code), [OpenCode](https://github.com/anomalyco/opencode), and [Codex CLI](https://github.com/openai/codex) out of the box. Other agents can be run via `agent-vm shell`.
 
 Never install attack vectors such as npm, claude or even Docker on your host machine again!
 
@@ -61,7 +61,7 @@ Creates a persistent VM for the current directory (or reuses it if one already e
 
 Each agent runs with its respective auto-approve flag:
 - `claude` runs with `--dangerously-skip-permissions`
-- `opencode` runs with `--dangerously-skip-permissions`
+- `opencode` does not yet have an auto-approve flag (waiting on [this PR](https://github.com/anomalyco/opencode/pull/11833))
 - `codex` runs with `--full-auto`
 
 Any extra arguments are forwarded to the agent command:

--- a/agent-vm.setup.sh
+++ b/agent-vm.setup.sh
@@ -67,7 +67,7 @@ echo 'export PS1="vm:%1~%% "' >> ~/.zshrc
 
 # Install OpenCode
 echo "Installing OpenCode..."
-curl -fsSL https://raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install | bash
+curl -fsSL https://opencode.ai/install | bash
 echo 'export PATH=$HOME/.opencode/bin:$PATH' >> ~/.zshrc
 
 # Add PATH to .zshenv so non-interactive shells (limactl shell vmname cmd) also find the tools

--- a/agent-vm.sh
+++ b/agent-vm.sh
@@ -365,7 +365,9 @@ _agent_vm_opencode() {
 
   _agent_vm_ensure_running "$vm_name" "$host_dir" "${vm_opts[@]}" || return 1
 
-  limactl shell --workdir "$host_dir" "$vm_name" opencode --dangerously-skip-permissions "${args[@]}"
+  # TODO: add --dangerously-skip-permissions once released
+  # (waiting on https://github.com/anomalyco/opencode/pull/11833)
+  limactl shell --workdir "$host_dir" "$vm_name" opencode "${args[@]}"
 }
 
 _agent_vm_codex() {


### PR DESCRIPTION
## Summary

- **Update OpenCode install URL** to official `https://opencode.ai/install` — the old script (`raw.githubusercontent.com/opencode-ai/opencode/refs/heads/main/install`) was fetching an outdated v0.5.5 instead of the latest (1.2.6)
- **Remove `--dangerously-skip-permissions` flag** for opencode — the feature is not yet released, waiting on https://github.com/anomalyco/opencode/pull/11833
- **Fix OpenCode repo link** in README — `opencode-ai/opencode` is archived (now called Crush), the correct repo is `anomalyco/opencode`

## Test plan

- [ ] Run `agent-vm setup` and verify OpenCode installs latest version
- [ ] Run `agent-vm opencode` and verify it launches without errors (no unknown flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)