### PR TITLE
Fix opencode TUI by forcing TTY allocation

### DIFF
--- a/agent-vm.sh
+++ b/agent-vm.sh
@@ -367,7 +367,7 @@ _agent_vm_opencode() {
 
   # TODO: add --dangerously-skip-permissions once released
   # (waiting on https://github.com/anomalyco/opencode/pull/11833)
-  limactl shell --workdir "$host_dir" "$vm_name" opencode "${args[@]}"
+  limactl shell --tty --workdir "$host_dir" "$vm_name" opencode "${args[@]}"
 }
 
 _agent_vm_codex() {


### PR DESCRIPTION
## Summary

- Add `--tty` flag to `limactl shell` when running opencode
- Without explicit TTY allocation, opencode shows the help menu instead of launching its TUI
- Claude doesn't need this because it handles TTY detection differently

## Test plan

- [ ] Run `agent-vm opencode` and verify the TUI launches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)