### PR TITLE
setup rbenv/ruby-build for ruby projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ npm install
 docker compose up -d
 ```
 
+For Ruby projects, install your Ruby version in the runtime script:
+
+```bash
+# your-project/.agent-vm.runtime.sh
+rbenv install 3.3.0 --skip-existing
+rbenv local 3.3.0
+bundle install
+```
+
 ### MCP servers
 
 The base VM comes with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) pre-configured for Claude, giving the agent headless browser access.
@@ -201,6 +210,7 @@ Each VM is fully isolated — agents must authenticate independently inside thei
 |----------|----------|
 | Core | git, curl, wget, jq, build-essential, unzip, zip |
 | Python | python3, pip, venv |
+| Ruby | rbenv, ruby-build (no version pre-installed) |
 | Node.js | Node.js 24 LTS (via NodeSource) |
 | Search | ripgrep, fd-find |
 | Utilities | htop, GitHub CLI (gh) |

--- a/agent-vm.setup.sh
+++ b/agent-vm.setup.sh
@@ -23,10 +23,25 @@ sudo apt-get install -y \
   ripgrep fd-find htop \
   unzip zip \
   ca-certificates \
-  iptables
+  iptables \
+  libssl-dev libreadline-dev zlib1g-dev libyaml-dev libffi-dev
 
 # Set zsh as default shell
 sudo chsh -s /usr/bin/zsh "$(whoami)"
+
+# Install rbenv + ruby-build (Ruby version manager)
+echo "Installing rbenv and ruby-build..."
+git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
+
+# Auto-install bundler after every rbenv install
+echo "bundler" > ~/.rbenv/default-gems
+
+# Configure rbenv in shell
+echo 'export PATH=$HOME/.rbenv/bin:$PATH' >> ~/.zshrc
+echo 'eval "$(rbenv init -)"' >> ~/.zshrc
+echo 'export PATH=$HOME/.rbenv/bin:$PATH' >> ~/.zshenv
+echo 'eval "$(rbenv init -)"' >> ~/.zshenv
 
 # Install Docker from official repo (includes docker compose)
 echo "Installing Docker..."


### PR DESCRIPTION
At datagouv/api.gouv.fr we're going to use this tool within our projects (it will be referenced in https://github.com/datagouv/rails_ai_rules/) and we have multiple Rails projects.
  
I'm not sure if this fits the philosophy of the tool, felt better to open a PR to discuss than an issue.