### PR TITLE
Add runtime.example.sh and document global runtime setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,46 @@ pip install pandas numpy
 
 ### Per-user runtime: `~/.agent-vm/runtime.sh`
 
-Create this file to run commands inside every VM on each start. Runs before the per-project runtime script:
+Create this file to run commands inside every VM on each start. It runs **before** the per-project `.agent-vm.runtime.sh` script.
+
+Use it for anything that should be available in all your VMs: SSH keys, git config, GitHub CLI auth, Claude Code skills, MCP servers, etc.
+
+**Getting started:**
 
 ```bash
-# ~/.agent-vm/runtime.sh
-export MY_API_KEY="..."
+cp runtime.example.sh ~/.agent-vm/runtime.sh
+# Edit with your own values
+```
+
+See [`runtime.example.sh`](runtime.example.sh) for a fully commented template covering:
+- SSH key injection for GitHub (base64-encoded private key)
+- Git identity and SSH-forced remotes (`url.insteadOf`)
+- GitHub CLI authentication (`gh auth login --with-token`)
+- Claude Code skills installation (global and per-project)
+- MCP server registration (`claude mcp add --scope user`)
+- Status line configuration in `~/.claude/settings.json`
+
+**Encoding your SSH key:**
+
+```bash
+cat ~/.ssh/id_ed25519 | base64
+```
+
+Paste the output into your `runtime.sh` — the script decodes it at boot and sets up `~/.ssh` with proper permissions.
+
+**Global vs per-project runtime:**
+
+| File | Scope | Runs when |
+|------|-------|-----------|
+| `~/.agent-vm/runtime.sh` | All VMs | Every VM start, first |
+| `.agent-vm.runtime.sh` | Current project only | Every VM start, after global |
+
+**Important:** Always launch `agent-vm` from a path without spaces. macOS iCloud paths contain spaces (`~/Library/Mobile Documents/...`), which can break mounts. Create a symlink instead:
+
+```bash
+ln -s ~/Library/Mobile\ Documents/com~apple~CloudDocs/Dev ~/Dev
+cd ~/Dev/your-project
+agent-vm claude
 ```
 
 ### Per-project: `.agent-vm.runtime.sh`

--- a/runtime.example.sh
+++ b/runtime.example.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# =============================================================================
+# runtime.example.sh — Template for ~/.agent-vm/runtime.sh
+# =============================================================================
+#
+# This file runs inside every agent-vm on each start, before the per-project
+# .agent-vm.runtime.sh script. Copy it to ~/.agent-vm/runtime.sh and uncomment
+# the sections you need.
+#
+# To get started:
+#   cp runtime.example.sh ~/.agent-vm/runtime.sh
+#   # Edit the file with your own values
+#   chmod +x ~/.agent-vm/runtime.sh
+
+
+# =============================================================================
+# 1. SSH authentication for GitHub
+# =============================================================================
+#
+# Embed your SSH private key (base64-encoded) so the VM can push/pull over SSH.
+#
+#   To encode your key:
+#     cat ~/.ssh/id_ed25519 | base64
+#
+#   Paste the output below:
+
+# SSH_KEY_B64="<your-base64-encoded-private-key>"
+# mkdir -p ~/.ssh && chmod 700 ~/.ssh
+# echo "$SSH_KEY_B64" | base64 -d > ~/.ssh/id_ed25519
+# chmod 600 ~/.ssh/id_ed25519
+# ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+
+
+# =============================================================================
+# 2. Git configuration
+# =============================================================================
+
+# git config --global user.name "Your Name"
+# git config --global user.email "you@example.com"
+
+# Force SSH for all GitHub remotes (avoids HTTPS credential prompts)
+# git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+
+# =============================================================================
+# 3. GitHub CLI authentication
+# =============================================================================
+#
+# Required for creating PRs, commenting on issues, etc. from inside the VM.
+#
+#   To create a token: https://github.com/settings/tokens
+#   Scopes needed: repo, read:org
+#
+# echo "<your-github-pat>" | gh auth login --with-token
+
+
+# =============================================================================
+# 4. Claude Code skills
+# =============================================================================
+#
+# Clone shared skills into the global skills directory.
+# These will be available in all projects.
+
+# mkdir -p ~/.claude/skills
+# git clone git@github.com:your-org/claude-skills.git ~/.claude/skills/your-org-skills
+
+# You can also install skills into the current project's directory.
+# These will only be available when working in that project.
+
+# PROJECT_DIR="$(pwd)"
+# mkdir -p "$PROJECT_DIR/.claude/skills"
+# git clone git@github.com:your-org/project-skills.git "$PROJECT_DIR/.claude/skills/project-skills"
+
+
+# =============================================================================
+# 5. MCP servers
+# =============================================================================
+#
+# Add MCP servers available to Claude Code in all projects (--scope user).
+#
+# claude mcp add --scope user my-mcp-server npx -y my-mcp-server@latest
+
+
+# =============================================================================
+# 6. Claude Code status line
+# =============================================================================
+#
+# Install a custom status line command in ~/.claude/settings.json.
+# The command output is displayed at the bottom of the Claude Code interface.
+#
+# For example, to show the current git branch:
+#
+# cat > /tmp/statusline-patch.json << 'PATCH'
+# {"statusLine": {"command": "git branch --show-current 2>/dev/null || echo ''"}}
+# PATCH
+#
+# if [ -f ~/.claude/settings.json ]; then
+#   jq -s '.[0] * .[1]' ~/.claude/settings.json /tmp/statusline-patch.json > /tmp/settings-merged.json
+#   mv /tmp/settings-merged.json ~/.claude/settings.json
+# else
+#   mkdir -p ~/.claude
+#   cp /tmp/statusline-patch.json ~/.claude/settings.json
+# fi
+# rm -f /tmp/statusline-patch.json


### PR DESCRIPTION
## Summary

- Add `runtime.example.sh`: a fully commented template for `~/.agent-vm/runtime.sh` covering SSH auth, git config, GitHub CLI, Claude Code skills, MCP servers, and status line setup
- Expand the "Per-user runtime" section in `README.md` with detailed documentation, a comparison table (global vs per-project runtime), SSH key encoding instructions, and the iCloud spaces workaround

## Test plan

- [ ] Verify `runtime.example.sh` is valid bash (`bash -n runtime.example.sh`)
- [ ] Copy to `~/.agent-vm/runtime.sh`, uncomment sections, and test in a fresh VM
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)