### PR TITLE
add per-tool launch flag overrides via flags config

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,28 @@ mise install
 bundle install
 ```
 
+### Agent launch flags: `~/.agent-vm/flags` / `.agent-vm.flags`
+
+By default `agent-vm` launches the agents with sane permissive flags
+(`claude --dangerously-skip-permissions`, `codex --full-auto`). If those
+defaults conflict with your setup — for example a `.agent-vm.runtime.sh` that
+wires up DB access which `codex --full-auto` then refuses — override them per
+tool:
+
+```
+# ~/.agent-vm/flags or <project>/.agent-vm.flags
+codex --dangerously-bypass-approvals-and-sandbox
+claude --dangerously-skip-permissions
+opencode
+```
+
+These files are parsed as **data**, not sourced as shell — a repo can't run
+code on your host through them. One line per tool: `<tool> [flag ...]`.
+Comments (`#`) and blank lines are ignored. Listing a tool replaces its
+defaults entirely (a bare tool name launches it with no flags). Per-project
+file overrides per-user. Args passed on the command line are still appended
+after these flags. See [`flags.example`](flags.example).
+
 ### MCP servers
 
 The base VM comes with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) pre-configured for Claude, giving the agent headless browser access.

--- a/agent-vm.sh
+++ b/agent-vm.sh
@@ -192,6 +192,56 @@ _agent_vm_ensure_running() {
   fi
 }
 
+# Resolve launch flags for a tool, with user/project overrides.
+# Reads ~/.agent-vm/flags then <project>/.agent-vm.flags as DATA (not shell);
+# project entries override user entries override built-in defaults. A line
+# matching the tool replaces the default flags entirely (a bare tool line
+# yields an empty flag list). Prints flags one per line.
+# Usage: _agent_vm_load_flags <tool> <host_dir> [default_flag ...]
+_agent_vm_load_flags() {
+  local tool="$1"
+  local host_dir="$2"
+  shift 2
+  local defaults=("$@")
+
+  local defined=""
+  local out=()
+  local file
+  for file in "$AGENT_VM_STATE_DIR/flags" "$host_dir/.agent-vm.flags"; do
+    [[ -f "$file" ]] || continue
+    local marker=""
+    local parsed=()
+    local line
+    while IFS= read -r line; do
+      if [[ -z "$marker" ]]; then
+        marker="$line"
+      else
+        parsed+=("$line")
+      fi
+    done < <(awk -v t="$tool" '
+      /^[[:space:]]*#/ { next }
+      /^[[:space:]]*$/ { next }
+      $1 == t {
+        found = 1
+        for (i = 2; i <= NF; i++) flags[++n] = $i
+      }
+      END {
+        if (found) {
+          print "1"
+          for (i = 1; i <= n; i++) print flags[i]
+        }
+      }
+    ' "$file")
+    if [[ "$marker" == "1" ]]; then
+      defined=1
+      out=("${parsed[@]}")
+    fi
+  done
+
+  [[ -z "$defined" ]] && out=("${defaults[@]}")
+  [[ ${#out[@]} -gt 0 ]] && printf '%s\n' "${out[@]}"
+}
+
 agent-vm() {
   local vm_opts=()
   # Parse global options before the subcommand
@@ -321,7 +371,9 @@ VMs are persistent and unique per directory. Running "agent-vm shell" or
 Customization:
   ~/.agent-vm/setup.sh              Per-user setup (runs during "agent-vm setup")
   ~/.agent-vm/runtime.sh            Per-user runtime (runs on each VM start)
+  ~/.agent-vm/flags                 Per-user agent launch flags overrides
   <project>/.agent-vm.runtime.sh    Per-project runtime (runs on each VM start)
+  <project>/.agent-vm.flags         Per-project agent launch flags overrides
 
 More info: https://github.com/sylvinus/agent-vm
 EOF
@@ -455,8 +507,11 @@ _agent_vm_claude() {
   _agent_vm_ensure_running "$vm_name" "$host_dir" "${vm_opts[@]}" || return 1
   _agent_vm_print_resources "$vm_name"
 
+  local flags=()
+  while IFS= read -r line; do flags+=("$line"); done < <(_agent_vm_load_flags claude "$host_dir" --dangerously-skip-permissions)
+
   local exit_code=0
-  limactl shell --workdir "$host_dir" "$vm_name" claude --dangerously-skip-permissions "${args[@]}"
+  limactl shell --workdir "$host_dir" "$vm_name" claude "${flags[@]}" "${args[@]}"
   exit_code=$?
   [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
   return $exit_code
@@ -489,8 +544,11 @@ _agent_vm_opencode() {
 
   # TODO: add --dangerously-skip-permissions once released
   # (waiting on https://github.com/anomalyco/opencode/pull/11833)
+  local flags=()
+  while IFS= read -r line; do flags+=("$line"); done < <(_agent_vm_load_flags opencode "$host_dir")
+
   local exit_code=0
-  limactl shell --tty --workdir "$host_dir" "$vm_name" opencode "${args[@]}"
+  limactl shell --tty --workdir "$host_dir" "$vm_name" opencode "${flags[@]}" "${args[@]}"
   exit_code=$?
   [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
   return $exit_code
@@ -521,8 +579,11 @@ _agent_vm_codex() {
   _agent_vm_ensure_running "$vm_name" "$host_dir" "${vm_opts[@]}" || return 1
   _agent_vm_print_resources "$vm_name"
 
+  local flags=()
+  while IFS= read -r line; do flags+=("$line"); done < <(_agent_vm_load_flags codex "$host_dir" --full-auto)
+
   local exit_code=0
-  limactl shell --workdir "$host_dir" "$vm_name" codex --full-auto "${args[@]}"
+  limactl shell --workdir "$host_dir" "$vm_name" codex "${flags[@]}" "${args[@]}"
   exit_code=$?
   [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
   return $exit_code

--- a/flags.example
+++ b/flags.example
@@ -1,0 +1,29 @@
+# agent-vm launch flags overrides
+#
+# Copy to one of:
+#   ~/.agent-vm/flags             (per-user, applies to every VM)
+#   <project>/.agent-vm.flags     (per-project, overrides the user file)
+#
+# This file is parsed as DATA — never sourced as shell — so a malicious
+# repository cannot run code on the host through it.
+#
+# Format: one line per agent (claude, codex, opencode):
+#   <tool> [flag ...]
+# Lines starting with # and blank lines are ignored.
+#
+# Listing a tool REPLACES the default launch flags for it. A bare tool name
+# (no flags) launches it with no flags. Omit a tool entirely to keep the
+# built-in defaults below:
+#   claude    --dangerously-skip-permissions
+#   codex     --full-auto
+#   opencode  (none)
+#
+# Args passed on the command line (e.g. `agent-vm codex -p "..."`) are still
+# appended after these flags.
+#
+# Example: bypass codex sandbox/approvals so a project runtime that wires up
+# DB access or other system tweaks isn't blocked by --full-auto.
+# codex --dangerously-bypass-approvals-and-sandbox
+
+# claude --dangerously-skip-permissions
+# opencode


### PR DESCRIPTION
Each agent (claude, codex, opencode) was launched with a single hardcoded set of flags baked into agent-vm.sh. That works for the common case but leaves no room to adapt the launch to a given project or user preference: swapping a permission/sandbox mode, dropping a flag entirely, or adding agent-specific options all required editing agent-vm.sh itself.

Introduce two new config files following the existing nomenclature:

  ~/.agent-vm/flags           per-user overrides
  <project>/.agent-vm.flags   per-project overrides (wins over user)

Both files are parsed as DATA, never sourced as shell. This matters for the project-level file: a malicious or compromised repo could otherwise execute arbitrary code on the host as soon as you run `agent-vm` in it, defeating the VM isolation model. The format is one line per agent:

  codex --dangerously-bypass-approvals-and-sandbox
  claude --dangerously-skip-permissions
  opencode

Listing a tool replaces its defaults entirely (a bare tool line yields an empty flag list). Omitting a tool keeps its built-in default. CLI args passed to `agent-vm <tool>` are still appended after these flags.

A concrete motivating case: project runtimes that wire up DB access via `.agent-vm.runtime.sh` are blocked by `codex --full-auto`'s sandbox, and this mechanism lets the user swap in `--dangerously-bypass-approvals-and-sandbox` without touching agent-vm.sh.