### PR TITLE
run codex with --dangerously-bypass-approvals-and-sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Creates a persistent VM for the current directory (or reuses it if one already e
 Each agent runs with its respective auto-approve flag:
 - `claude` runs with `--dangerously-skip-permissions`
 - `opencode` does not yet have an auto-approve flag (waiting on [this PR](https://github.com/anomalyco/opencode/pull/11833))
-- `codex` runs with `--full-auto`
+- `codex` runs with `--dangerously-bypass-approvals-and-sandbox`
 
 Any extra arguments are forwarded to the agent command:
 

--- a/agent-vm.sh
+++ b/agent-vm.sh
@@ -522,7 +522,7 @@ _agent_vm_codex() {
   _agent_vm_print_resources "$vm_name"
 
   local exit_code=0
-  limactl shell --workdir "$host_dir" "$vm_name" codex --full-auto "${args[@]}"
+  limactl shell --workdir "$host_dir" "$vm_name" codex --dangerously-bypass-approvals-and-sandbox "${args[@]}"
   exit_code=$?
   [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
   return $exit_code


### PR DESCRIPTION
Aligns codex's default behavior with claude's --dangerously-skip-permissions. The Lima VM is already the sandbox, so Codex's inner --full-auto sandbox is redundant and actively harmful — it blocks the agent from reaching services running on the Lima host itself (e.g. a database running in the VM outside Codex's sandbox). Bypassing approvals + sandbox keeps the trust boundary at the VM level, consistent with the other agents.