### PR TITLE
feat: add native support for Mistral Vibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run AI coding agents inside sandboxed Linux VMs. The agent gets full autonomy wh
 
 Uses [Lima](https://lima-vm.io/) to create lightweight Debian VMs on macOS and Linux. Ships with dev tools, Docker, and a headless Chrome browser with [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) pre-configured.
 
-Supports [Claude Code](https://claude.ai/code), [OpenCode](https://github.com/anomalyco/opencode), and [Codex CLI](https://github.com/openai/codex) out of the box. Other agents can be run via `agent-vm shell`.
+Supports [Claude Code](https://claude.ai/code), [OpenCode](https://github.com/anomalyco/opencode), [Codex CLI](https://github.com/openai/codex), and [Mistral Vibe](https://docs.mistral.ai/vibe/code/cli/install-setup) out of the box. Other agents can be run via `agent-vm shell`.
 
 Never install attack vectors such as npm, claude or even Docker on your host machine again!
 
@@ -56,6 +56,7 @@ cd your-project
 agent-vm claude                # Claude Code
 agent-vm opencode              # OpenCode
 agent-vm codex                 # Codex CLI
+agent-vm vibe                  # Mistral Vibe
 ```
 
 Creates a persistent VM for the current directory (or reuses it if one already exists), mounts your working directory, and runs the agent with full permissions. The VM persists after the agent exits so you can reconnect later. Ports opened inside the VM (e.g. by Docker containers or dev servers) are automatically forwarded to your host by Lima.
@@ -64,6 +65,7 @@ Each agent runs with its respective auto-approve flag:
 - `claude` runs with `--dangerously-skip-permissions`
 - `opencode` does not yet have an auto-approve flag (waiting on [this PR](https://github.com/anomalyco/opencode/pull/11833))
 - `codex` runs with `--dangerously-bypass-approvals-and-sandbox`
+- `vibe` runs with `--agent auto-approve`
 
 Any extra arguments are forwarded to the agent command:
 
@@ -72,6 +74,7 @@ agent-vm claude -p "fix all lint errors"        # Run with a prompt
 agent-vm claude --resume                         # Resume previous session
 agent-vm opencode -p "refactor auth module"      # OpenCode with a prompt
 agent-vm codex -q "explain this codebase"        # Codex with a query
+agent-vm vibe -p "fix all lint errors"           # Mistral Vibe with a prompt
 ```
 
 ### Shell access and running commands

--- a/agent-vm.setup.sh
+++ b/agent-vm.setup.sh
@@ -85,9 +85,12 @@ echo 'export PATH=$HOME/.local/bin:$HOME/.claude/local/bin:$HOME/.opencode/bin:$
 echo "Installing Codex CLI..."
 sudo npm i -g @openai/codex
 
-# Install Mistral Vibe (installs uv and the `vibe`/`vibe-acp` commands into ~/.local/bin,
-# which is already on PATH via the lines added above)
+# Install Mistral Vibe (installs uv and the `vibe`/`vibe-acp` commands into ~/.local/bin).
+# This setup script runs under bash, but the PATH export lives in ~/.zshrc/~/.zshenv, so
+# ~/.local/bin isn't on PATH here yet. The Vibe installer exits non-zero (aborting setup
+# under `set -e`) if it can't find its install dir on PATH, so export it for this session.
 echo "Installing Mistral Vibe..."
+export PATH="$HOME/.local/bin:$PATH"
 curl -LsSf https://mistral.ai/vibe/install.sh | bash
 
 # Configure Chrome DevTools MCP server for Claude

--- a/agent-vm.setup.sh
+++ b/agent-vm.setup.sh
@@ -85,6 +85,11 @@ echo 'export PATH=$HOME/.local/bin:$HOME/.claude/local/bin:$HOME/.opencode/bin:$
 echo "Installing Codex CLI..."
 sudo npm i -g @openai/codex
 
+# Install Mistral Vibe (installs uv and the `vibe`/`vibe-acp` commands into ~/.local/bin,
+# which is already on PATH via the lines added above)
+echo "Installing Mistral Vibe..."
+curl -LsSf https://mistral.ai/vibe/install.sh | bash
+
 # Configure Chrome DevTools MCP server for Claude
 echo "Configuring Chrome MCP server for Claude..."
 CONFIG="$HOME/.claude.json"
@@ -130,6 +135,24 @@ else
   }
 }
 JSON
+fi
+
+# Configure Chrome DevTools MCP server for Vibe
+# Vibe uses TOML; append an array-of-tables entry (valid even if the wizard later
+# writes to the same file). Guard against duplicates on repeated setup runs.
+echo "Configuring Chrome MCP server for Vibe..."
+VIBE_CONFIG_DIR="$HOME/.vibe"
+mkdir -p "$VIBE_CONFIG_DIR"
+VIBE_CONFIG="$VIBE_CONFIG_DIR/config.toml"
+if ! grep -q 'name = "chrome-devtools"' "$VIBE_CONFIG" 2>/dev/null; then
+  cat >> "$VIBE_CONFIG" << 'TOML'
+
+[[mcp_servers]]
+name = "chrome-devtools"
+transport = "stdio"
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--headless=true", "--isolated=true"]
+TOML
 fi
 
 echo "VM setup complete."

--- a/agent-vm.sh
+++ b/agent-vm.sh
@@ -11,6 +11,7 @@
 #   agent-vm claude   - Run Claude Code in a persistent VM for cwd
 #   agent-vm opencode - Run OpenCode in a persistent VM for cwd
 #   agent-vm codex    - Run Codex CLI in a persistent VM for cwd
+#   agent-vm vibe     - Run Mistral Vibe in a persistent VM for cwd
 #   agent-vm shell    - Open a shell in the persistent VM for cwd
 #   agent-vm stop     - Stop the VM for cwd
 #   agent-vm rm       - Stop and delete the VM for cwd
@@ -255,6 +256,9 @@ agent-vm() {
     codex)
       _agent_vm_codex "${vm_opts[@]}" "$@"
       ;;
+    vibe)
+      _agent_vm_vibe "${vm_opts[@]}" "$@"
+      ;;
     shell)
       _agent_vm_shell "${vm_opts[@]}" "$@"
       ;;
@@ -296,6 +300,7 @@ Commands:
   claude [args]      Run Claude Code in the VM for the current directory
   opencode [args]    Run OpenCode in the VM for the current directory
   codex [args]       Run Codex CLI in the VM for the current directory
+  vibe [args]        Run Mistral Vibe in the VM for the current directory
   shell              Open a shell in the VM for the current directory
   run <cmd> [args]   Run a command in the VM for the current directory
   stop               Stop the VM for the current directory
@@ -305,7 +310,7 @@ Commands:
   status             Show status of all VMs (current dir marked with >)
   help               Show this help
 
-VM options (for claude, opencode, codex, shell, run):
+VM options (for claude, opencode, codex, vibe, shell, run):
   --disk GB          VM disk size (default: 10)
   --memory GB        VM memory (default: 2)
   --cpus N           Number of CPUs (default: 1)
@@ -320,6 +325,7 @@ Examples:
   agent-vm claude                            # Run Claude in a VM
   agent-vm opencode                          # Run OpenCode in a VM
   agent-vm codex                             # Run Codex in a VM
+  agent-vm vibe                              # Run Mistral Vibe in a VM
   agent-vm --disk 50 --memory 16 --cpus 8 claude  # Custom resources
   agent-vm --reset claude                    # Fresh VM from base template
   agent-vm --rm claude                       # Destroy VM after Claude exits
@@ -441,7 +447,7 @@ _agent_vm_setup() {
   date +%s > "$AGENT_VM_STATE_DIR/.agent-vm-base-version"
 
   echo ""
-  echo "Base VM ready. Run 'agent-vm shell', 'agent-vm claude', 'agent-vm opencode', or 'agent-vm codex' in any project directory."
+  echo "Base VM ready. Run 'agent-vm shell', 'agent-vm claude', 'agent-vm opencode', 'agent-vm codex', or 'agent-vm vibe' in any project directory."
   echo "Note: Existing VMs were not updated. Use --reset to re-clone them from the new base."
 }
 
@@ -538,6 +544,40 @@ _agent_vm_codex() {
 
   local exit_code=0
   limactl shell --workdir "$host_dir" "$vm_name" codex --dangerously-bypass-approvals-and-sandbox "${args[@]}"
+  exit_code=$?
+  [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
+  return $exit_code
+}
+
+_agent_vm_vibe() {
+  local vm_opts=()
+  local args=()
+  local rm=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --disk)     vm_opts+=(--disk "$2"); shift 2 ;;
+      --memory|--ram)   vm_opts+=(--memory "$2"); shift 2 ;;
+      --cpus)     vm_opts+=(--cpus "$2"); shift 2 ;;
+      --reset)    vm_opts+=(--reset); shift ;;
+      --offline)  vm_opts+=(--offline); shift ;;
+      --readonly) vm_opts+=(--readonly); shift ;;
+      --git-read-only|--git-ro) vm_opts+=(--git-read-only); shift ;;
+      --rm)       rm=1; shift ;;
+      *)          args+=("$1"); shift ;;
+    esac
+  done
+  local host_dir
+  host_dir="$(pwd)"
+  local vm_name
+  vm_name="$(_agent_vm_name "$host_dir")"
+
+  _agent_vm_ensure_running "$vm_name" "$host_dir" "${vm_opts[@]}" || return 1
+  _agent_vm_print_resources "$vm_name"
+
+  # Vibe is a full-screen TUI, so allocate a tty (like opencode).
+  # --agent auto-approve gives full autonomy (safe inside the sandbox).
+  local exit_code=0
+  limactl shell --tty --workdir "$host_dir" "$vm_name" vibe --agent auto-approve "${args[@]}"
   exit_code=$?
   [[ -n "$rm" ]] && { echo "Removing VM..."; _agent_vm_destroy; }
   return $exit_code


### PR DESCRIPTION
## What

Adds [Mistral Vibe](https://docs.mistral.ai/vibe/code/cli/install-setup) as a first-class agent, alongside `claude`, `opencode` and `codex`. Until now Vibe could only be run manually via `agent-vm shell` (re-installed for every VM).

## Changes

- **`agent-vm.setup.sh`**: install the `vibe` CLI in the base VM (`curl -LsSf https://mistral.ai/vibe/install.sh | bash` — installs `uv` and drops `vibe`/`vibe-acp` into `~/.local/bin`, already on `PATH`), and pre-configure the Chrome DevTools MCP server in `~/.vibe/config.toml` (TOML `[[mcp_servers]]`, appended idempotently).
- **`agent-vm.sh`**: new `agent-vm vibe` command + `_agent_vm_vibe` runner. Runs with `--agent auto-approve` for full autonomy inside the sandbox (matching the auto-approve convention of the other agents) and `--tty` since Vibe is a full-screen TUI (like `opencode`). Help text and header comments updated.
- **`README.md`**: documents the new agent.

## Notes

- Authentication works like the other agents — inside the persistent per-directory VM — via `MISTRAL_API_KEY` (e.g. exported in `~/.agent-vm/runtime.sh`) or Vibe's first-launch setup wizard.
- In `-p/--prompt` mode Vibe already defaults to the `auto-approve` agent; passing `--agent auto-approve` also makes interactive sessions fully autonomous.

## Testing

- `bash -n` passes on both scripts.
- `agent-vm help` lists the new `vibe` command.
- After `agent-vm setup`: `agent-vm run vibe --version` resolves the binary, and `~/.vibe/config.toml` contains the `chrome-devtools` MCP entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)